### PR TITLE
[15.0][FIX] web_search_with_and

### DIFF
--- a/web_search_with_and/static/src/js/search_bar.js
+++ b/web_search_with_and/static/src/js/search_bar.js
@@ -27,7 +27,7 @@ odoo.define("web_search_with_and/static/src/js/search_bar.js", function (require
                     filterId: source.filterId,
                     value:
                         "value" in source
-                            ? source.value.trim()
+                            ? source.value
                             : this._parseWithSource(labelValue, source).trim(),
                     label: labelValue.trim(),
                     operator: source.filterOperator || source.operator,


### PR DESCRIPTION
When we search by the id of any record and not a string, it gives an error on the line: ? source.value.trim(). It is because the value of sorce.value is an integer. To fix it, we do the trim() operation just if source.value is an string.