### PR TITLE
[FIX] .trim() de _parseWithSource()

### DIFF
--- a/web_search_with_and/static/src/js/search_bar.js
+++ b/web_search_with_and/static/src/js/search_bar.js
@@ -28,7 +28,7 @@ odoo.define("web_search_with_and/static/src/js/search_bar.js", function (require
                     value:
                         "value" in source
                             ? source.value
-                            : this._parseWithSource(labelValue, source).trim(),
+                            : this._parseWithSource(labelValue.trim(), source),
                     label: labelValue.trim(),
                     operator: source.filterOperator || source.operator,
                     isShiftKey: this.isShiftKey,


### PR DESCRIPTION
El .trim() de la línea 31 está mal posicionado, porque el resultado de la operación _parseWithSource() puede ser un entero, y no podemos hacer el .trim(). Se debe poner detrás del labelValue, que siempre será un string.